### PR TITLE
add newsvalues for events and newscoverage, use value attribute

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,23 @@
+name: Lint code
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.0'
+          cache: false # Let golangcilint handle caching
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.56
+          args: --timeout=4m

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+name: Run tests
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.0'
+      - name: Run go tests
+        run: |
+          go test ./...

--- a/core.json
+++ b/core.json
@@ -523,10 +523,33 @@
       "meta": [
         {
           "declares": {"type":"core/newsvalue"},
+          "maxCount": 1,
+          "attributes": {
+            "value": {
+              "description": "The assigned newsvalue, optional if score is used. Will become mandatory.",
+              "format": "int",
+              "optional": true
+            }
+          },
           "data": {
-            "duration": {"format":"int", "optional": true},
-            "score": {"format":"int"},
-            "end": {"format":"RFC3339", "optional":true}
+            "duration": {
+              "description": "Duration in seconds, can represent the halving time for the score in a scoring algorithm.",
+              "format":"int",
+              "optional": true
+            },
+            "score": {
+              "format":"int",
+              "optional": true,
+              "deprecated": {
+                "label": "newsvalue-score",
+                "doc": "use the value attribute instead"
+              }
+            },
+            "end": {
+              "description": "The cut-off time that the document has no newsvalue",
+              "format":"RFC3339",
+              "optional":true
+            }
           }
         }
       ],
@@ -784,7 +807,25 @@
             "registration": {"allowEmpty":true},
             "start": {"format":"RFC3339"},
             "end": {"format":"RFC3339"},
-            "priority": {"format":"int"}
+            "priority": {
+              "format":"int",
+              "optional": true,
+              "deprecated": {
+                "label": "event-prio",
+                "doc": "Use newsvalue block instead"
+              }
+            }
+          }
+        },
+        {
+          "description": "Newsvalue will become mandatory in the future",
+          "declares": {"type":"core/newsvalue"},
+          "maxCount": 1,
+          "attributes": {
+            "value": {
+              "description": "The assigned newsvalue",
+              "format":"int"
+            }
           }
         }
       ],
@@ -927,9 +968,27 @@
             "startDate": {"time":"2006-01-02"},
             "end": {"format":"RFC3339"},
             "endDate": {"time":"2006-01-02"},
-            "priority": {"format":"int"},
+            "priority": {
+              "format":"int",
+              "optional": true,
+              "deprecated": {
+                "label": "newscoverage-prio",
+                "doc": "Use newsvalue block instead"
+              }
+            },
             "publicDescription":{"allowEmpty":true},
             "slug": {"allowEmpty":true}
+          }
+        },
+        {
+          "description": "Newsvalue will become mandatory in the future",
+          "declares": {"type":"core/newsvalue"},
+          "maxCount": 1,
+          "attributes": {
+            "value": {
+              "description": "The assigned newsvalue",
+              "format":"int"
+            }
           }
         }
       ],


### PR DESCRIPTION
Starts the transition from data[score] to @value for the actual newsvalue. Expect to finalise this before we go 1.0.