### PR TITLE
add support for flash documents

### DIFF
--- a/core-planning.json
+++ b/core-planning.json
@@ -164,7 +164,9 @@
               },
               "minCount": 1,
               "attributes": {
-                "value": {}
+                "value": {
+                  "enumReference": "core://assignment-types"
+                }
               }
             },
             {
@@ -241,6 +243,17 @@
           ]
         }
       ]
+    }
+  ],
+  "enums": [
+    {
+      "declare": "core://assignment-types",
+      "values": {
+        "text": {},
+        "picture": {},
+        "video": {},
+        "graphics": {}
+      }
     }
   ]
 }

--- a/core.json
+++ b/core.json
@@ -20,7 +20,7 @@
           "declares": {"type":"core/place-type"},
           "attributes": {
             "value": {
-              "enumReference": "core/place-types"
+              "enumReference": "core://place-types"
             }
           }
         },
@@ -36,7 +36,7 @@
           "declares": {"type":"core/place"},
           "attributes": {
             "rel": {
-              "enumReference": "core/place-relationships"
+              "enumReference": "core://place-relationships"
             },
             "title": {},
             "uuid": {}
@@ -337,6 +337,52 @@
       ]
     },
     {
+      "name": "Flash",
+      "description": "Flash news is used for quick breaking news items",
+      "declares": "core/flash",
+      "attributes": {
+        "title": {}
+      },
+      "meta": [
+        {
+          "name": "Section",
+          "declares": {"rel":"section", "type": "core/section"},
+          "attributes": {
+            "uuid": {},
+            "title": {}
+          }
+        }
+      ],
+      "links": [
+        {
+          "name": "Assignment",
+          "description": "A link to the assignment that the flash belongs to",
+          "declares": {"type": "core/assignment", "rel":"assignment"},
+          "attributes": {
+            "uuid": {}
+          }
+        }
+      ],
+      "content": [
+        {
+          "description": "A flash text block",
+          "declares": {"type":"core/text"},
+          "attributes": {
+            "role": {
+              "optional": true,
+              "enumReference": "core://flash-text-roles"
+            }
+          },
+          "data": {
+            "text":{
+              "allowEmpty":true,
+              "format": "html"
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "Article",
       "description": "An editorial article",
       "declares": "core/article",
@@ -451,7 +497,7 @@
           "attributes": {
             "uuid": {}
           }
-        }        
+        }
       ]
     },
     {
@@ -695,7 +741,7 @@
   ],
   "enums": [
     {
-      "declare": "core/text-roles",
+      "declare": "core://text-roles",
       "name": "Text block roles",
       "values": {
         "heading-1": {},
@@ -707,7 +753,14 @@
       }
     },
     {
-      "declare": "core/place-types",
+      "declare": "core://flash-text-roles",
+      "name": "Text block roles for flashes",
+      "values": {
+        "heading-1": {}
+      }
+    },
+    {
+      "declare": "core://place-types",
       "name": "Place types",
       "values": {
         "country": {},
@@ -721,7 +774,7 @@
       }
     },
     {
-      "declare": "core/place-relationships",
+      "declare": "core://place-relationships",
       "name": "Place relationships",
       "values": {
         "country": {},
@@ -843,7 +896,7 @@
         "attributes": {
           "role": {
             "optional":true,
-            "enumReference": "core/text-roles"
+            "enumReference": "core://text-roles"
           }
         },
         "data": {

--- a/tt.json
+++ b/tt.json
@@ -3,7 +3,7 @@
   "name": "tt",
   "enums": [
     {
-      "match": "core/text-roles",
+      "match": "core://text-roles",
       "values": {
         "heading-3": {"forbidden":true},
         "heading-4": {"forbidden":true},


### PR DESCRIPTION
Sneaking in a change in how we declare and reference enums. Using URIs rather than types to identify things feels like the way to go. Didn't want to introduce a new typeish enum, so I'm fixing this while it's easy