### PR TITLE
Sweeping updates

### DIFF
--- a/core-planning.json
+++ b/core-planning.json
@@ -90,7 +90,12 @@
             },
             "public": {
               "description": "Whether (a scrubbed version of) this planning item can be made publicly available.",
-              "format": "bool"
+              "format": "bool",
+              "optional": true,
+              "deprecated": {
+                "label": "public-planning",
+                "doc": "use the status 'publish' instead"
+              }
             },
             "tentative": {
               "description": "Whether the planning item is tentative.",

--- a/core-planning.json
+++ b/core-planning.json
@@ -52,6 +52,17 @@
             "uuid": {},
             "title": {}
           }
+        },
+        {
+          "name": "The associated place for the planning item",
+          "declares": {
+            "rel": "place",
+            "type": "core/place"
+          },
+          "attributes": {
+            "uuid": {},
+            "title": {}
+          }
         }
       ],
       "meta": [

--- a/core-planning.json
+++ b/core-planning.json
@@ -94,7 +94,7 @@
               "optional": true,
               "deprecated": {
                 "label": "public-planning",
-                "doc": "use the status 'publish' instead"
+                "doc": "use the status 'usable' instead"
               }
             },
             "tentative": {

--- a/core.json
+++ b/core.json
@@ -534,6 +534,7 @@
         {"ref": "core://note"}
       ],
       "links": [
+        {"ref": "core://byline"},
         {
           "name": "Section",
           "declares": {"rel":"section", "type": "core/section"},

--- a/core.json
+++ b/core.json
@@ -1154,34 +1154,9 @@
               }
             }
           },
-          {
-            "declares": {"type":"core/unordered-list"},
-            "content": [
-              {
-                "declares": {"type":"core/text"},
-                "data": {
-                  "text":{
-                    "allowEmpty": true,
-                    "format": "html"
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "declares": {"type":"core/ordered-list"},
-            "content": [
-              {
-                "declares": {"type":"core/text"},
-                "data": {
-                  "text":{
-                    "allowEmpty": true,
-                    "format": "html"
-                  }
-                }
-              }
-            ]
-          }
+          {"ref": "core://ordered-list"},
+          {"ref": "core://unordered-list"},
+          {"ref": "core://table"}
         ]
       }
     },

--- a/core.json
+++ b/core.json
@@ -567,6 +567,7 @@
       "declares": "core/contact",
       "meta": [
         {"ref":"core://definition"},
+        {"ref":"core://note"},
         {
           "name": "Main metadata block",
           "declares": {"type":"core/contact"},

--- a/core.json
+++ b/core.json
@@ -556,7 +556,10 @@
     {
       "name": "Contacts group",
       "description": "A group used to categorise contacts",
-      "declares": "core/group"
+      "declares": "core/group",
+      "meta": [
+        {"ref":"core://definition"}
+      ]
     },
     {
       "name": "Contact information",

--- a/core.json
+++ b/core.json
@@ -363,24 +363,8 @@
       },
       "links": [
         {"ref": "core://byline"},
-        {
-          "name": "Section",
-          "count": 1,
-          "declares": {"rel":"section", "type": "core/section"},
-          "attributes": {
-            "uuid": {},
-            "title": {}
-          }
-        },
-        {
-          "name": "Assignment",
-          "count": 1,
-          "description": "A link to the assignment that the flash belongs to",
-          "declares": {"type": "core/assignment", "rel":"assignment"},
-          "attributes": {
-            "uuid": {}
-          }
-        }
+        {"ref": "core://section"},
+        {"ref": "core://assignment"}
       ],
       "content": [
         {
@@ -426,22 +410,9 @@
       ],
       "links": [
         {"ref": "core://byline"},
-        {
-          "name": "Section",
-          "declares": {"rel":"section", "type": "core/section"},
-          "attributes": {
-            "uuid": {},
-            "title": {"allowEmpty":true}
-          }
-        },
-        {
-          "name": "Story",
-          "declares": {"type": "core/story", "rel":"subject"},
-          "attributes": {
-            "uuid": {},
-            "title": {"allowEmpty":true}
-          }
-        },
+        {"ref": "core://story"},
+        {"ref": "core://section"},
+        {"ref": "core://assignment"},
         {
           "name": "Publishing channel",
           "declares": {"rel":"channel", "type": "core/channel"},
@@ -509,14 +480,6 @@
           "attributes": {
             "uuid": {}
           }
-        },
-        {
-          "name": "Assignment",
-          "description": "A link to the assignment that the article was produced for",
-          "declares": {"type": "core/assignment", "rel":"assignment"},
-          "attributes": {
-            "uuid": {}
-          }
         }
       ]
     },
@@ -535,22 +498,9 @@
       ],
       "links": [
         {"ref": "core://byline"},
-        {
-          "name": "Section",
-          "declares": {"rel":"section", "type": "core/section"},
-          "attributes": {
-            "uuid": {},
-            "title": {"allowEmpty":true}
-          }
-        },
-        {
-          "name": "Assignment",
-          "description": "A link to the assignment that the article was produced for",
-          "declares": {"type": "core/assignment", "rel":"assignment"},
-          "attributes": {
-            "uuid": {}
-          }
-        }
+        {"ref": "core://story"},
+        {"ref": "core://section"},
+        {"ref": "core://assignment"}
       ]
     },
     {
@@ -1261,6 +1211,39 @@
           "longDescription": {"optional":true},
           "shortDescription": {"optional":true},
           "phone": {"optional":true}
+        }
+      }
+    },
+    {
+      "id": "core://story",
+      "block": {
+        "name": "Story",
+        "declares": {"type": "core/story", "rel":"subject"},
+        "attributes": {
+          "uuid": {},
+          "title": {"allowEmpty":true}
+        }
+      }
+    },
+    {
+      "id": "core://section",
+      "block": {
+        "name": "Section",
+        "declares": {"rel":"section", "type": "core/section"},
+        "attributes": {
+          "uuid": {},
+          "title": {"allowEmpty":true}
+        }
+      }
+    },
+    {
+      "id": "core://assignment",
+      "block": {
+        "name": "Assignment",
+        "description": "A link to the assignment that the document was produced for",
+        "declares": {"type": "core/assignment", "rel":"assignment"},
+        "attributes": {
+          "uuid": {}
         }
       }
     }

--- a/core.json
+++ b/core.json
@@ -734,14 +734,14 @@
             "title": {}
           },
           "data": {
-            "country": {},
-            "extraInfo": {"allowEmpty": true},
+            "country": {"optional":true},
+            "extraInfo": {"optional": true},
             "geometry": {
               "format": "wkt",
               "geometry": "point"
             },
-            "locality": {},
-            "name": {}
+            "locality": {"optional":true},
+            "name": {"optional":true}
           }
         },
         {

--- a/core.json
+++ b/core.json
@@ -518,6 +518,38 @@
       ]
     },
     {
+      "name": "Editorial information",
+      "description": "Information for editorial staff",
+      "declares": "core/editorial-info",
+      "content": [
+        {"ref": "core://text"},
+        {"ref": "core://image"},
+        {"ref": "core://unordered-list"},
+        {"ref": "core://ordered-list"}
+      ],
+      "meta": [
+        {"ref": "core://note"}
+      ],
+      "links": [
+        {
+          "name": "Section",
+          "declares": {"rel":"section", "type": "core/section"},
+          "attributes": {
+            "uuid": {},
+            "title": {"allowEmpty":true}
+          }
+        },
+        {
+          "name": "Assignment",
+          "description": "A link to the assignment that the article was produced for",
+          "declares": {"type": "core/assignment", "rel":"assignment"},
+          "attributes": {
+            "uuid": {}
+          }
+        }
+      ]
+    },
+    {
       "name": "Contacts group",
       "description": "A group used to categorise contacts",
       "declares": "core/group"

--- a/core.json
+++ b/core.json
@@ -730,7 +730,11 @@
           "name": "Geo position",
           "declares": {"type":"core/geo-point", "rel": "location"},
           "attributes": {
-            "uri": {"glob":["geo://point/*"]},
+            "uri": {
+              "glob":["geo://point/*"],
+              "optional": true,
+              "description": "TODO: where did this URI format come from?"
+            },
             "title": {}
           },
           "data": {

--- a/core.json
+++ b/core.json
@@ -76,7 +76,10 @@
     {
       "name": "Topic",
       "description": "An topic for content",
-      "declares": "core/topic"
+      "declares": "core/topic",
+      "meta": [
+        {"ref":"core://definition"}
+      ]
     },
     {
       "name": "Story",

--- a/tt.json
+++ b/tt.json
@@ -35,12 +35,12 @@
           }
         },
         {
-          "name": "Birthday date in UTC",
+          "name": "Birthday date",
           "declares": {"type":"tt/birthday"},
           "count": 1,
           "attributes": {
             "value": {
-              "format": "RFC3339",
+              "time": "2006-01-02",
               "optional": true
             }
           },

--- a/tt.json
+++ b/tt.json
@@ -25,7 +25,6 @@
       ],
       "meta": [
         {"ref": "core://definition"},
-        {"ref": "core://note"},
         {
           "name": "Contact information",
           "declares": {"type":"core/contact"},

--- a/tt.json
+++ b/tt.json
@@ -25,6 +25,7 @@
       ],
       "meta": [
         {"ref": "core://definition"},
+        {"ref": "core://note"},
         {
           "name": "Contact information",
           "declares": {"type":"core/contact"},

--- a/tt.json
+++ b/tt.json
@@ -39,7 +39,16 @@
           "declares": {"type":"tt/birthday"},
           "count": 1,
           "attributes": {
-            "value": {"format":"RFC3339"}
+            "value": {
+              "format": "RFC3339",
+              "optional": true
+            }
+          },
+          "data": {
+            "year": {
+              "format":"int",
+              "optional": true
+            }
           }
         }
       ]


### PR DESCRIPTION
The biggest change is that we now have editorial information documents (tillred). Second is that the "public" attribute on planning items has been deprecated. Other than that it's mostly small changes driven by discovered data and changes in the OC importer.