### PR TITLE
add a content source document type

### DIFF
--- a/core.json
+++ b/core.json
@@ -75,8 +75,19 @@
     },
     {
       "name": "Topic",
-      "description": "An topic for content",
+      "description": "A topic for content",
       "declares": "core/topic",
+      "meta": [
+        {"ref":"core://definition"}
+      ]
+    },
+    {
+      "name": "Content source",
+      "description": "A content source that can be credited",
+      "declares": "core/content-source",
+      "attributes": {
+        "title": {}
+      },
       "meta": [
         {"ref":"core://definition"}
       ]
@@ -1263,6 +1274,9 @@
         "description": "The entity that is the source of the content, e.g. the organisation that produced it.",
         "declares": {"type": "core/content-source", "rel":"source"},
         "attributes": {
+          "uuid": {
+            "optional": true
+          },
           "uri": {},
           "title": {}
         }


### PR DESCRIPTION
Content sources can be used by the UI to populate options, and by wire sources/providers to link to a source that should be used when creating an article/assignment from a wire document.