### PR TITLE
extend the assignment statuses with en-route and finished

### DIFF
--- a/se.ecms.planning.json
+++ b/se.ecms.planning.json
@@ -307,6 +307,8 @@
       }
     },
     {
+      "name": "Assignment statuses",
+      "description": "Statuses used to describe what stage the work with an assignment has reached.",
       "declare": "core://assignment-statuses",
       "values": {
         "todo": {

--- a/se.ecms.planning.json
+++ b/se.ecms.planning.json
@@ -190,7 +190,7 @@
             },
             "status": {
               "optional": true,
-              "enum": ["todo", "started", "done"]
+              "enumReference": "core://assignment-statuses"
             }
           },
           "meta": [
@@ -304,6 +304,26 @@
         "graphic": {},
         "flash": {},
         "editorial-info": {}
+      }
+    },
+    {
+      "declare": "core://assignment-statuses",
+      "values": {
+        "todo": {
+          "description": "Pending task"
+        },
+        "en-route": {
+          "description": "Used when we want to communicate that a journalist/photographer is on the way"
+        },
+        "started": {
+          "description": "Work has started / photographer is at the scene"
+        },
+        "finished": {
+          "description": "Work has finished, but we still might be waiting for deliverables to arrive or be approved"
+        },
+        "done": {
+          "description": "Everything is done, no more deliverables forthcoming for the assignment"
+        }
       }
     }
   ]


### PR DESCRIPTION
* todo: pending task
* en-route: used when we want to communicate that a journalist/photographer is on the way
* started: work has started / photographer is at the scene
* finished: work has finished, but we still might be waiting for deliverables to arrive or be approved
* done: everything is done, no more deliverables forthcoming for the assignment